### PR TITLE
Silence 'which'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ docker-push:
 # find or download controller-gen
 # download controller-gen if necessary
 controller-gen:
-ifeq (, $(shell which controller-gen))
+ifeq (, $(shell which controller-gen 2> /dev/null))
 	@{ \
 	set -e ;\
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\


### PR DESCRIPTION
Otherwise it would warn about 'controller-gen' not in $PATH, which
is exactly what's being handled here.